### PR TITLE
feat: Support all possible env vars for the onetimesecret image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+charts
+.idea

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 20.3.0
+digest: sha256:f29baceb675ebb114cf711534fe31cbfb0ce515d84e9ee5d4c07816696c92886
+generated: "2025-02-06T16:50:21.930551-05:00"

--- a/templates/onetimesecret-deployment.yaml
+++ b/templates/onetimesecret-deployment.yaml
@@ -20,29 +20,17 @@ spec:
         ports:
         - containerPort: {{ include "onetimesecret-service.port" $ }}
         env:
+        {{- if .Values.redis.enabled }}
         - name: REDIS_URL
           value: {{ include "onetimesecret-chart.redis.url" $ }}
-        - name: COLONEL
-          value: "{{ .Values.onetimesecret.env.COLONEL }}"
+        {{- end }}
+        {{- if .Values.ingress.enabled }}
         - name: HOST
           {{- with (first .Values.ingress.hosts) }}
           value: "{{ .host }}"
           {{- end  }}
-        - name: SSL
-          value: "{{ .Values.onetimesecret.env.SSL }}"
-        - name: SMTP_HOST
-          value: "{{ .Values.onetimesecret.env.SMTP_HOST }}"
-        - name: SMTP_PORT
-          value: "{{ .Values.onetimesecret.env.SMTP_PORT }}"
-        - name: SMTP_USERNAME
-          value: "{{ .Values.onetimesecret.env.SMTP_USERNAME }}"
-        - name: SMTP_PASSWORD
-          value: "{{ .Values.onetimesecret.env.SMTP_PASSWORD }}"
-        - name: FROM_EMAIL
-          value: "{{ .Values.onetimesecret.env.FROM_EMAIL }}"
-        - name: TO_EMAIL
-          value: "{{ .Values.onetimesecret.env.TO_EMAIL }}" 
-        - name: AUTH_SIGNUP
-          value: "{{ .Values.onetimesecret.env.AUTH_SIGNUP }}"
-        - name: AUTH_SIGNIN
-          value: "{{ .Values.onetimesecret.env.AUTH_SIGNIN }}"    
+        {{- end }}
+        {{- range $key, $value := .Values.onetimesecret.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}


### PR DESCRIPTION
Currently, you can't add any of the additional configuration options available for the OTS image. This PR makes the ENV list dynamic and able to accept any variable.
