### PR TITLE
Add condition on redis dependency

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -30,3 +30,4 @@ dependencies:
   - name: redis
     version: 20.7.0  # Choose the appropriate version
     repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled


### PR DESCRIPTION
There is currently no condition on the Redis dependency (setting `redis.enabled: false` has no effect). This PR ensures that Redis is not deployed if `redis.enabled: false`.